### PR TITLE
partial fix for https://github.com/BBj-Plugins/BBjGridExWidget/issues…

### DIFF
--- a/BBjGridExWidget.bbj
+++ b/BBjGridExWidget.bbj
@@ -675,7 +675,9 @@ class public BBjGridExWidget extends BBjWidget implements BBjGridExWidgetColumns
             FI
             htmlview!.setOpaque(0)
             htmlview!.setNoEdge(1)
-            
+            htmlview!.setTabTraversable(1)
+            htmlview!.setFocusable(1)
+
             
 
             if (info(3,6)<>"5" and #Debug>0) then
@@ -688,6 +690,7 @@ class public BBjGridExWidget extends BBjWidget implements BBjGridExWidgetColumns
 
             htmlview!.setCallback(BBjAPI.ON_PAGE_LOADED,#this!,"onInit")
             htmlview!.setCallback(BBjAPI.ON_NATIVE_JAVASCRIPT,#this!,"onNativeEvent")
+            htmlview!.setCallback(BBjAPI.ON_GAINED_FOCUS,#this!,"onGainedFocus")            
             htmlview!.setText(html$)
             
             #HTMLView!=htmlview!
@@ -809,6 +812,10 @@ REM         #onLoaded(null())
 
         BBjAPI().createTimer(str(#this!)+"onLoadFallback",.2,#this!,"onLoaded")
         
+    methodend
+    method public void onGainedFocus( BBjEvent ev! )
+        rem @Hyyan: need something here to make the grid just grab the focus, but not change it
+        #focus()
     methodend
     rem /**
     rem  * On Loaded event listener will flush the callbacks queue and clear all ON_PAGE_LOADED
@@ -1926,7 +1933,9 @@ REM         #onLoaded(null())
     rem  * @param BBjStrinf column! The column id
     rem  */
     method public void focus(BBjString row! , BBjString column!)
-        #super!.focus()
+        if #HTMLView!.getParentWindow().getFocusedControlID() <>  #HTMLView!.getID() then
+            #HTMLView!.focus()
+        fi
         script$="gw_setFocusedCell('" + #GRIDID$ + "','" + str(row!) + "','" + str(column!) + "');"
         #executeScript(script$)
     methodend

--- a/demo/CD-Store.bbj
+++ b/demo/CD-Store.bbj
@@ -22,6 +22,7 @@ REM init the grid
 grid! = new BBjGridExWidget(wnd!,100,0,0,800,600)
 
 gosub main
+grid!.focus()
 process_events
 
 rem /**

--- a/demo/Demo.bbj
+++ b/demo/Demo.bbj
@@ -15,7 +15,7 @@ declare auto BBjToolButton btn_fit!
 declare BBjGridExWidget grid!
 
 ? 'HIDE'
-wnd! = BBjAPI().openSysGui("X0").addWindow(10,10,900,600,"BBj Grid Ex Demo")
+wnd! = BBjAPI().openSysGui("X0").addWindow(10,10,900,600,"BBj Grid Ex Demo",$00010083$)
 wnd!        .setCallback(BBjAPI.ON_CLOSE,"byebye")
 wnd!        .setCallback(BBjAPI.ON_RESIZE,"resize")
 if (info(3,6)<>"5") then
@@ -43,6 +43,7 @@ REM init the grid
 grid! = new BBjGridExWidget(wnd!,100,0,35,900,563)
 grid!.getOptions().setEnableFilter(1) 
 
+
 gosub loadDatabases
 gosub doQuery
 
@@ -51,6 +52,8 @@ rem enable to get the full db browsing functionality
 rem lb_db!.setEnabled(0)
 lb_theme!.insertItems(0, grid!.getThemes())
 lb_theme!.selectIndex(0)
+
+lb_db!.focus()
 
 process_events
 


### PR DESCRIPTION
…/181

@hyyan 
Please review this PR, it's not quite a complete fix. I believe we need something in the wrapping JS code that drags the focus into the grid without changing the actual selection. Play with Demo.bbj - the BBj controls on top of the grid are all focusable and can be traversed with the Tab key (note that the tool button to the right is not focusable / tab traversable so it's not part of the keyboard tab order).
